### PR TITLE
[design/#17] 푸터 position 제거, 반응형 제거

### DIFF
--- a/src/components/commons/footer/Footer.tsx
+++ b/src/components/commons/footer/Footer.tsx
@@ -64,8 +64,7 @@ const Footer = () => {
 export default Footer;
 
 const FooterWrapper = styled.footer`
-  position: fixed;
-  bottom: 0;
+  width: 1366px;
 
   background-color: ${({ theme }) => theme.colors.gray100};
 `;

--- a/src/pages/wishList/WishList.tsx
+++ b/src/pages/wishList/WishList.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { WishListThumIcon } from '../../assets/svgs';
+import Footer from '../../components/commons/footer/Footer';
 import { WishHeader } from '../../components/commons/Header';
 
 const WishList = () => {
@@ -23,6 +24,7 @@ const WishList = () => {
           </WishDetail>
         </WishCardWrapper>
       </WishListWrapper>
+      <Footer />
     </>
   );
 };
@@ -40,11 +42,6 @@ const WishListWrapper = styled.div`
   padding: 4.2rem 10rem;
 
   border-top: 1px solid ${({ theme }) => theme.colors.gray200};
-
-  @media (width <= 1166px) {
-    position: absolute;
-    left: 0;
-  }
 `;
 
 const Title = styled.h1`
@@ -59,6 +56,7 @@ const WishCardWrapper = styled.article`
   gap: 1.2rem;
   align-items: flex-start;
   justify-content: center;
+  margin-bottom: 22.5rem;
 `;
 
 const WishDetail = styled.div`

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -32,6 +32,7 @@ const GlobalStyle = styled.createGlobalStyle`
   }
 
   body {
+    /* position: relative; */
     display: flex;
     justify-content: center;
     width: 100%;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #17 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 푸터 position 제거
- [x] 반응형 제거

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->
- 우리 페이지마다 패딩이 달라서 .. 반응형 최대한 해보려고 했는데 깨져서 그냥 반응형 고려 안하는 방향으로 가겠슴니다 ~
- 각 페이지 최상단 wrapper에 양옆 패딩값 빼서 미디어 쿼리 적용하라고 했었는데, 그냥 그렇게 말고 width: 1366px로 넣어놓고 각 페이지 padding 먹이고 작업하시면 됩니다잉~
- 푸터에 position: fixed 먹혀있었는데 제가 스크롤 되는 경우를 고려를 안하고 만들어서 ,,, 포지션 제거해두었습니다앗 !!

## 📌 질문할 부분 
- 없슴

## 📌스크린샷
<!-- 스크린샷은 필수로 업로드해주세요 (스크린샷/영상/노션 링크 무관) -->
